### PR TITLE
hide form after successful submit

### DIFF
--- a/assets/js/commit.coffee
+++ b/assets/js/commit.coffee
@@ -62,6 +62,7 @@ App.Commit = (->
           title:  'Nice!'
           text:   json.message
           type:   'success'
+        @form.style.display = 'none'
     xobj.send JSON.stringify data
 
 


### PR DESCRIPTION
dont have a good local environment to check this on, but i believe this will work. @aegaas can you verify it hides on success? my other doubt is that the xhr event steals `this` from the callback and `@form` will be undefined. but i'm pretty sure we're good.