### PR TITLE
remove 'hash' based cache busters on app.css and app.js

### DIFF
--- a/app.production.coffee
+++ b/app.production.coffee
@@ -9,7 +9,7 @@ records         = require 'roots-records'
 shell           = require 'shelljs'
 copyLibrary     = require './scripts/copy-library'
 createThumbs    = require './scripts/create-thumbs'
-hash            = (new Date()).valueOf().toString()
+# hash            = (new Date()).valueOf().toString()
 
 module.exports =
   ignores: [
@@ -63,7 +63,7 @@ module.exports =
         'assets/js/ga-prod.coffee'
         'assets/js/elqQ.coffee'
       ]
-      out:    "js/app_#{hash}.js"
+      out:    "js/app.js"
       minify: true
       hash:   false
 
@@ -84,7 +84,7 @@ module.exports =
         'bower_components/sweetalert/dist/sweetalert.css'
         'assets/css/master.styl'
       ]
-      out:    "css/app_#{hash}.css"
+      out:    "css/app.css"
       minify: true
       hash:   false
       opts:
@@ -124,6 +124,6 @@ module.exports =
     createThumbs()
 
   after: ->
-    shell.exec "node_modules/purify-css/bin/purifycss public/css/app_#{hash}.css public/index.html public/feed.html public/about.html public/authors.html public/commit.html public/posts/argyleink/webviews.html public/js/app_#{hash}.js --info --out public/css/app_#{hash}.css"
-    shell.exec "node_modules/csso/bin/csso public/css/app_#{hash}.css public/css/app_#{hash}.css"
+    shell.exec "node_modules/purify-css/bin/purifycss public/css/app.css public/index.html public/feed.html public/about.html public/authors.html public/commit.html public/posts/argyleink/webviews.html public/js/app.js --info --out public/css/app.css"
+    shell.exec "node_modules/csso/bin/csso public/css/app.css public/css/app.css"
     shell.exec 'cp -R posts/* public/posts'

--- a/views/layouts/_general.jade
+++ b/views/layouts/_general.jade
@@ -8,7 +8,7 @@ include ../mixins/_feed-home-item
 include ../mixins/_related-post
 
 doctype html
-html
+html(lang='en')
 
   head
     include ../includes/_font-strategy

--- a/views/layouts/_single.jade
+++ b/views/layouts/_single.jade
@@ -5,7 +5,7 @@ include ../mixins/_related-post
 include ../mixins/_tracking-pixel
 
 doctype html
-html
+html(lang='en')
   - var author = helpers.getAuthor(post, data)
   - var git = helpers.getPostGitData(post, records)
 


### PR DESCRIPTION
need a visual inspection before deployment since Travis cannot test prod only functionality.